### PR TITLE
Fix(api): Repara la función admin-supa y actualiza la clave

### DIFF
--- a/netlify/functions/admin-supa.js
+++ b/netlify/functions/admin-supa.js
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
-// VERSION: 3.0 - Claves hardcodeadas para evitar problemas de variables de entorno
+// VERSION: 3.1 - Lógica de parseo corregida y placeholder para API key
 const supabaseUrl = 'https://fcvwqwjsypossdqochde.supabase.co';
-const supabaseServiceRole = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZjdndxd2pzeXBvc3NkcW9jaGRlIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MjA3MTgxNjA4N30.6P-J5cQbnSBGYP27jJ33JVCO23z_JcoTFgqmGZDgPXE';
+// JULES: Usando la nueva clave secreta (equivalente a service_role) proporcionada por el usuario.
+const supabaseServiceRole = 'sb_secret_NvlzgPG5fvSb1pfuy_TVBw_n7v9RHmy';
 
 const supabase = createClient(supabaseUrl, supabaseServiceRole);
 
@@ -74,9 +75,15 @@ export async function handler(event) {
       // Para otros métodos, parsear el body normalmente
       const bodyData = JSON.parse(event.body || '{}');
       action = bodyData.action;
-      data = bodyData.data;
       id = bodyData.id;
-      console.log('✅ Body parseado:', { action, data, id });
+
+      // FIX: La acción 'update_setting' envía los datos en el nivel superior, no anidados.
+      if (action === 'update_setting') {
+        data = { key: bodyData.key, value: bodyData.value };
+      } else {
+        data = bodyData.data;
+      }
+      console.log('✅ Body parseado (lógica corregida):', { action, data, id });
     }
     
     console.log('📝 Datos finales:', { action, data, id, method: event.httpMethod });


### PR DESCRIPTION
Se realizan dos cambios críticos en la función de Netlify `admin-supa`:

1.  Se corrige un bug en la lógica de parseo del cuerpo de la petición. La función no manejaba correctamente el payload de la acción `update_setting`, lo que causaba un `TypeError`. La lógica ahora distingue entre los diferentes formatos de payload.

2.  Se actualiza la clave de servicio de Supabase (`service_role`) a la nueva `secret_key` proporcionada. La clave anterior estaba invalidada y causaba errores de autenticación (401) en todas las llamadas a Supabase.

Estos cambios deberían restaurar por completo la funcionalidad CRUD del dashboard.