### PR TITLE
Fix(api): Corrige la operación upsert para evitar errores de clave du…

### DIFF
--- a/netlify/functions/admin-supa.js
+++ b/netlify/functions/admin-supa.js
@@ -164,7 +164,7 @@ export async function handler(event) {
         // Usar upsert para insertar o actualizar
         result = await supabase
           .from('app_settings')
-          .upsert({ key: data.key, value: data.value })
+          .upsert({ key: data.key, value: data.value }, { onConflict: 'key' })
           .select()
           .single();
         console.log('Resultado update_setting:', result);


### PR DESCRIPTION
…plicada

    La llamada `upsert` a la tabla `app_settings` no especificaba la columna de conflicto. Esto causaba un error de 'duplicate key' al intentar actualizar un ajuste existente.

    Se ha añadido la opción `{ onConflict: 'key' }` a la llamada `upsert` para asegurar que las filas existentes se actualicen correctamente en lugar de intentar una inserción fallida.